### PR TITLE
Update runtime to 6.9, use PySide basepp, update modules, add x-checker-data

### DIFF
--- a/io.github.shmmodbus.shm-modbus.yml
+++ b/io.github.shmmodbus.shm-modbus.yml
@@ -29,6 +29,10 @@ modules:
       - type: git
         tag: v3.3.1
         url: https://github.com/jarro2783/cxxopts.git
+        commit: 44380e5a44706ab7347f400698c703eb2a196202
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: cxxshm
     buildsystem: cmake-ninja
@@ -43,6 +47,10 @@ modules:
       - type: git
         tag: v2.0.4
         url: https://github.com/NikolasK-source/cxxshm.git
+        commit: 2bce9d6cc80a9903fecf35048d43d950bc91b8fc
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: cxxsemaphore
     buildsystem: cmake-ninja
@@ -57,6 +65,10 @@ modules:
       - type: git
         tag: v2.0.4
         url: https://github.com/NikolasK-source/cxxsemaphore.git
+        commit: 013d56fb690df3bcf77f35bddd68f165272b9867
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: cxxitimer
     buildsystem: cmake-ninja
@@ -71,6 +83,10 @@ modules:
       - type: git
         tag: v2.0.4
         url: https://github.com/NikolasK-source/cxxitimer.git
+        commit: 65fc36980cc62e073f5f7f9f3ac11779492cf107
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: nlohmann_json
     buildsystem: cmake-ninja
@@ -80,6 +96,10 @@ modules:
       - type: git
         tag: v3.12.0
         url: https://github.com/nlohmann/json.git
+        commit: 55f93686c01528224f448c19128836e7df245f72
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: libmodbus
     buildsystem: autotools
@@ -87,6 +107,10 @@ modules:
       - type: git
         tag: v3.1.11
         url: https://github.com/stephane/libmodbus.git
+        commit: 5190e5e141780ae481f24be16d7b39a5f3ad8f8f
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: Modbus_TCP_client_shm
     buildsystem: cmake-ninja
@@ -101,7 +125,11 @@ modules:
       - type: git
         tag: v1.6.3
         url: https://github.com/SHMModbus/modbus_tcp_client_shm.git
+        commit: 2a894e26c7744657eba3c50e971621ec3897653c
         disable-shallow-clone: true
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: signal_gen
     buildsystem: simple
@@ -123,6 +151,10 @@ modules:
       - type: git
         tag: v2.1.2
         url: https://github.com/SHMModbus/shm_modbus_gui.git
+        commit: 6156252d4b13340e622f11d78b4ba4fa0a4e8d33
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: Modbus_RTU_client_shm
     buildsystem: cmake-ninja
@@ -136,7 +168,11 @@ modules:
       - type: git
         tag: v1.0.0
         url: https://github.com/SHMModbus/modbus_rtu_client_shm.git
+        commit: 48209d97157e417a6e74ecff29c486f6572d46a5
         disable-shallow-clone: true
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: write_shm
     buildsystem: cmake-ninja
@@ -151,6 +187,10 @@ modules:
       - type: git
         tag: v1.1.1
         url: https://github.com/SHMModbus/write_shm.git
+        commit: 3b3cee7da4afe464f052388c3b6aec5d0dafd89e
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: shm_format
     buildsystem: cmake-ninja
@@ -165,6 +205,10 @@ modules:
       - type: git
         tag: v2.0.1
         url: https://github.com/SHMModbus/shm_format.git
+        commit: fc79301861ea844c895aaff6e39bcaeab57395b4
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: SHM_random
     buildsystem: cmake-ninja
@@ -179,6 +223,10 @@ modules:
       - type: git
         tag: v1.4.1
         url: https://github.com/SHMModbus/shared_mem_random.git
+        commit: 092d73077e32699437b8295ffcc37d0345fa745c
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: dump_shm
     buildsystem: cmake-ninja
@@ -193,6 +241,10 @@ modules:
       - type: git
         tag: v1.3.1
         url: https://github.com/SHMModbus/dump_shm.git
+        commit: 7dad5bed7c052c02cea05a40b085899410f6f7bf
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: stdin-to-modbus-shm
     buildsystem: cmake-ninja
@@ -207,6 +259,10 @@ modules:
       - type: git
         tag: v1.5.0
         url: https://github.com/SHMModbus/stdin_to_modbus_shm.git
+        commit: 6acf2b259473749b5c38fbb416a43f85c72d265a
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: wago-modbus-coupler-shm
     buildsystem: cmake-ninja
@@ -221,6 +277,10 @@ modules:
       - type: git
         tag: v1.1.1
         url: https://github.com/SHMModbus/wago_modbus_coupler_shm.git
+        commit: 6bed8de3342132d191171be9af2208fe388dbde7
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
 
   - name: launch_scripts_and_metadata
     buildsystem: simple
@@ -234,3 +294,7 @@ modules:
       - type: git
         tag: v2.1.3
         url: https://github.com/SHMModbus/SHM_Modbus.git
+        commit: 4d6db04423b79769a8002af25041381b8dbab000
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
`x-checker-data` adds support for automatic updates of the modules ([see here](https://github.com/flathub-infra/flatpak-external-data-checker)).